### PR TITLE
Set landing page as default route

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -14,18 +14,19 @@ import Account from "./Account";
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const PAGES = {
-    
-    Dashboard: Dashboard,
-    
-    Generate: Generate,
-    
-    Cases: Cases,
-    
-    Case: Case,
-    
+
     Landing: Landing,
+
+    Dashboard: Dashboard,
+
+    Generate: Generate,
+
+    Cases: Cases,
+
+    Case: Case,
+
     Account: Account,
-    
+
 }
 
 function _getCurrentPage(url) {
@@ -50,7 +51,7 @@ function PagesContent() {
         <Layout currentPageName={currentPage}>
             <Routes>            
                 
-                    <Route path="/" element={<Dashboard />} />
+                    <Route path="/" element={<Landing />} />
                 
                 
                 <Route path="/Dashboard" element={<Dashboard />} />


### PR DESCRIPTION
## Summary
- reorder pages so landing page is first
- render `Landing` component on the `/` route

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884e933f1ac8327b15fcfc0ac3fa43e