### PR TITLE
Remove sidebar on landing page

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -45,6 +45,10 @@ const navigationItems = [
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
 
+  if (currentPageName === "Landing") {
+    return <div className="min-h-screen">{children}</div>;
+  }
+
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-gradient-to-br from-slate-50 to-slate-100">


### PR DESCRIPTION
## Summary
- return early from `Layout` when on Landing page so the sidebar is not rendered

## Testing
- `npm run lint` *(fails: no-undef and other issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884ed99c180832794fe4558625cb826