### PR TITLE
Connect landing to auth pages

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -31,8 +31,14 @@ export default function Dashboard() {
       ]);
       setCases(casesData);
       setUser(userData);
+      if (!userData?.subscription_tier) {
+        window.location.href = "/signup";
+        return;
+      }
     } catch (error) {
       console.error("Error loading dashboard data:", error);
+      window.location.href = "/login";
+      return;
     }
     setIsLoading(false);
   };

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -25,17 +25,36 @@ import {
   AccordionItem,
   AccordionTrigger
 } from "@/components/ui/accordion";
+import { User } from "@/api/entities";
 
 export default function Landing() {
   const [waitlistEmail, setWaitlistEmail] = useState("");
   const navigate = useNavigate();
 
   const handleStartFree = async () => {
-    navigate(createPageUrl("Dashboard"));
+    try {
+      const user = await User.me();
+      if (user?.subscription_tier) {
+        navigate(createPageUrl("Dashboard"));
+      } else {
+        window.location.href = "/signup";
+      }
+    } catch (e) {
+      window.location.href = "/signup";
+    }
   };
 
   const handleLogin = async () => {
-    navigate(createPageUrl("Dashboard"));
+    try {
+      const user = await User.me();
+      if (user) {
+        navigate(createPageUrl("Dashboard"));
+      } else {
+        window.location.href = "/login";
+      }
+    } catch (e) {
+      window.location.href = "/login";
+    }
   };
 
   return (
@@ -58,7 +77,7 @@ export default function Landing() {
             
             <div className="flex items-center gap-4">
               <Button variant="ghost" onClick={handleLogin}>
-                Go to Dashboard
+                Login
               </Button>
               <Button className="bg-blue-600 hover:bg-blue-700" onClick={handleStartFree}>
                 Get Started

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+export default function Login() {
+  useEffect(() => {
+    window.location.href = "/login";
+  }, []);
+
+  return (
+    <div className="p-8 text-center">Redirecting to login...</div>
+  );
+}

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+export default function Signup() {
+  useEffect(() => {
+    window.location.href = "/signup";
+  }, []);
+
+  return (
+    <div className="p-8 text-center">Redirecting to sign up...</div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -11,6 +11,8 @@ import Case from "./Case";
 import Landing from "./Landing";
 import Account from "./Account";
 import Payments from "./Payments";
+import Login from "./Login";
+import Signup from "./Signup";
 
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
@@ -29,6 +31,10 @@ const PAGES = {
     Account: Account,
 
     Payments: Payments,
+
+    Login: Login,
+
+    Signup: Signup,
 
 }
 
@@ -68,6 +74,8 @@ function PagesContent() {
                 <Route path="/Landing" element={<Landing />} />
                 <Route path="/Account" element={<Account />} />
                 <Route path="/Payments" element={<Payments />} />
+                <Route path="/Login" element={<Login />} />
+                <Route path="/Signup" element={<Signup />} />
 
             </Routes>
         </Layout>


### PR DESCRIPTION
## Summary
- add simple Login and Signup pages
- update routing to include Login and Signup
- link landing page buttons to Login/Signup
- restrict Dashboard to users with a subscription

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688502416d5c8327a1c2a5b370391e6f